### PR TITLE
Fix jsonl output formatting error in query command. Closes #8.

### DIFF
--- a/pipeline/querier/Cargo.toml
+++ b/pipeline/querier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "querier"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pipeline/querier/src/pipeline/colored_query_output.rs
+++ b/pipeline/querier/src/pipeline/colored_query_output.rs
@@ -195,7 +195,7 @@ pub fn colored_query_output<
                     })
                 {
                     jsonline_buffer.clear();
-                    write!(jsonline_buffer, "{{query_index:{}, matches:{{", query).unwrap();
+                    write!(jsonline_buffer, "{{\"query_index\":{}, \"matches\":{{", query).unwrap();
 
                     temp_colors_list.clear();
                     while query_colors_list_index != usize::MAX {


### PR DESCRIPTION
This is a minor change that quotes the `query_index` and `matches` keys in jsonl output for `query`. I also bumped the patch version of the querier crate to reflect the change. This closes #8.