### PR TITLE
Fix missing sequence normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "querier"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "byteorder",
  "colors",

--- a/pipeline/common/io/src/sequences_reader.rs
+++ b/pipeline/common/io/src/sequences_reader.rs
@@ -121,6 +121,7 @@ impl SequencesReader {
                 // If a new ident line is found (or it's the last line)
                 else if finished || (new_line && line.len() > 0 && line[0] == b'>') {
                     if intermediate[SEQ_STATE].len() > 0 {
+                        Self::normalize_sequence(&mut intermediate[SEQ_STATE]);
                         func(FastaSequence {
                             ident: &intermediate[IDENT_STATE],
                             seq: &intermediate[SEQ_STATE],


### PR DESCRIPTION
Fix missing sequence normalization that caused wrongly computed hashes leading to program crash. Fixes #10