### PR TITLE
Fix compiler error in C++ API.

### DIFF
--- a/crates/capi/ggcat-cpp-api/example/Makefile
+++ b/crates/capi/ggcat-cpp-api/example/Makefile
@@ -4,4 +4,4 @@
 all: ggcat-example
 
 ggcat-example: ../lib/libggcat_cpp_bindings.a ../lib/libggcat_cxx_interop.a ../lib/libggcat_api.a
-	g++ -flto -std=c++11 -O3 -I../include -L../lib main.cc -lggcat_api -lggcat_cpp_bindings -lggcat_cxx_interop -o ggcat-example
+	g++ -flto -std=c++11 -O3 -I../include -L../lib main.cc -lggcat_api -lggcat_cpp_bindings -lggcat_cxx_interop -o ggcat-example -lpthread -ldl

--- a/crates/capi/ggcat-cpp-api/include/ggcat.hh
+++ b/crates/capi/ggcat-cpp-api/include/ggcat.hh
@@ -18,7 +18,7 @@ namespace ggcat
 
         Slice(T *data, size_t size) : 
         // Avoid passing a null pointer to rust, as slices pointers are not allowed to be null
-        data(data ? data : UINTPTR_MAX), size(size) {}
+        data(data ? data : reinterpret_cast<T*>(UINTPTR_MAX)), size(size) {}
     };
 
     enum ExtraElaborationStep

--- a/crates/capi/ggcat-cpp-api/include/ggcat.hh
+++ b/crates/capi/ggcat-cpp-api/include/ggcat.hh
@@ -317,12 +317,13 @@ namespace ggcat
             // Overrides the default m-mers (minimizers) length
             size_t minimizer_length = -1)
         {
+            auto bridge_ptr = GGCATInstance::output_function_bridge<F>;
             this->dump_unitigs_internal(graph_input,
                                         kmer_length,
                                         minimizer_length,
                                         colors,
                                         threads_count,
-                                        (uintptr_t)&output_function, (uintptr_t)GGCATInstance::output_function_bridge<F>);
+                                        (uintptr_t)&output_function, reinterpret_cast<uintptr_t>(bridge_ptr));
         }
     };
 }


### PR DESCRIPTION
The error was:
./include/ggcat.hh:21:19: error: operands to ‘?:’ have different types ‘std::__cxx11::basic_string<char>*’ and ‘long unsigned int’
   21 |         data(data ? data : UINTPTR_MAX), size(size) {}