### PR TITLE
Fix AsyncSliceQueue

### DIFF
--- a/crates/colors/src/async_slice_queue.rs
+++ b/crates/colors/src/async_slice_queue.rs
@@ -65,7 +65,7 @@ impl<T: Copy, P: ChunksWriter<TargetData = T>> AsyncSliceQueue<T, P> {
     ) -> Self {
         let (sender, receiver) = crossbeam::channel::bounded(max_slices_buffers_count);
 
-        for _ in 1..max_slices_buffers_count {
+        for _ in 0..max_slices_buffers_count {
             sender
                 .send(Vec::with_capacity(slices_buffers_size))
                 .unwrap();


### PR DESCRIPTION
The for-loop in AsyncSliceQueue::new pushes only `max_slices_buffers_count-1` vectors to the chunks buffers pool. This is a problem at least when `max_slices_buffers_count` is 1, which is the case when the number of threads is 1, in which case nothing is pushed. The function add_data will then get stuck in the inner loop, because `self.chunks_buffers_pool.1.try_recv()` always fails because there is nothing in the pool.