### PR TITLE
Enable impl_trait_in_assoc_type feature

### DIFF
--- a/crates/assembler/src/lib.rs
+++ b/crates/assembler/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(slice_group_by, type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 use crate::pipeline::build_unitigs::build_unitigs;
 use crate::pipeline::compute_matchtigs::{compute_matchtigs_thread, MatchtigsStorageBackend};

--- a/crates/hashes/src/lib.rs
+++ b/crates/hashes/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(type_alias_impl_trait)]
 #![feature(const_type_id)]
+#![feature(impl_trait_in_assoc_type)]
 
 use dynamic_dispatch::dynamic_dispatch;
 

--- a/crates/kmers_transform/src/lib.rs
+++ b/crates/kmers_transform/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(type_alias_impl_trait)]
 #![feature(drain_filter)]
+#![feature(impl_trait_in_assoc_type)]
 
 mod reader;
 

--- a/crates/minimizer_bucketing/src/lib.rs
+++ b/crates/minimizer_bucketing/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(type_alias_impl_trait)]
+#![feature(impl_trait_in_assoc_type)]
 
 pub mod counters_analyzer;
 mod queue_data;


### PR DESCRIPTION
The build is currently broken on latest nightly because the feature impl_trait_in_assoc_type has been put behind a feature gate. I am getting errors like:

```
error[E0658]: `impl Trait` in associated types is unstable
  --> crates/hashes/src/cn_nthash.rs:63:25
   |
63 |       type IteratorType = impl Iterator<
   |  _________________________^
64 | |         Item = <CanonicalNtHashIteratorFactory as HashFunctionFactory>...
65 | |     >;
   | |_____^
   |
   = note: see issue #63063 <https://github.com/rust-lang/rust/issues/63063> for more information
   = help: add `#![feature(impl_trait_in_assoc_type)]` to the crate attributes to enable
```

This commit fixes these errors.