### PR TITLE
Fix C++ API makefile when compiler is not called g++

### DIFF
--- a/crates/capi/ggcat-cpp-api/Makefile
+++ b/crates/capi/ggcat-cpp-api/Makefile
@@ -9,7 +9,7 @@ clean:
 
 lib/libggcat_api.a: ./lib/libggcat_cpp_bindings.a
 	mkdir build/ -p
-	g++ -std=c++11 -O3 -I./include -I./src -c ./src/ggcat.cc -lggcat_cpp_bindings -lggcat_cxx_interop -o build/ggcat.o -Wall -Wextra -Werror
+	$(CXX) -std=c++11 -O3 -I./include -I./src -c ./src/ggcat.cc -lggcat_cpp_bindings -lggcat_cxx_interop -o build/ggcat.o -Wall -Wextra -Werror
 	ar cr lib/libggcat_api.a build/ggcat.o
 
 ./lib/libggcat_cpp_bindings.a: ggcat-source


### PR DESCRIPTION
Building the C++ API fails on systems where the GNU C++ compiler is called something other than g++ (this happens e.g. inside a conda recipe). Replacing the call to g++ with the Makefile environment variable $(CXX) fixes this.