### PR TITLE
Update to current version of matchtigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ target
 .idea
 .vscode
 working-dir/
+
+# Files for testingm
+*.fa
+*.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,16 +76,15 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
@@ -109,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -181,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "bigraph"
-version = "2.1.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dac072b4f13b3240d769598cbbc7a7aeb93900db329b1bd69d49ef8e8f24578"
+checksum = "acb6431ec45b2238d49e578ae6d71498dc5f9b6c007e0e0574f70fb60b09b912"
 dependencies = [
  "bitvector",
  "traitgraph",
@@ -272,12 +277,6 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -417,7 +416,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.3.2",
+ "bitflags",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -430,7 +429,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap 0.16.0",
@@ -438,33 +437,31 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.5.0",
- "once_cell",
+ "clap_lex 0.6.0",
  "strsim 0.10.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.63",
@@ -483,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cloudflare-zlib-sys"
@@ -529,14 +526,15 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compact-genome"
-version = "1.3.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1db9ae4fa1eaca78521c34cd0900972b260e36e3afb4d9cbf87ed0ef576a55d"
+checksum = "7b9bf5dfd6642561b3d70b4c9657ea8c0c2a5f072fb94e4bce7b230e929bd7e2"
 dependencies = [
  "bitvec",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "ref-cast",
+ "thiserror",
  "traitsequence",
 ]
 
@@ -568,7 +566,7 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-graphics-types",
  "foreign-types",
@@ -581,7 +579,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb142d41022986c1d8ff29103a1411c8a3dfad3552f87a4f8dc50d61d4f4e33"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "libc",
 ]
@@ -1026,7 +1024,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21fe28504d371085fae9ac7a3450f0b289ab71e07c8e57baa3fb68b9e57d6ce5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "core-foundation",
  "core-graphics",
@@ -1110,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "genome-graph"
-version = "5.2.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97db39cf8374ea039763603bed3d25ebe0594bb903433b16add92577d7e73cff"
+checksum = "de5c5b44a78e779835b77017dfa878343643f626ec9ccee967520eceae6115e7"
 dependencies = [
  "anyhow",
  "bigraph",
@@ -1198,7 +1196,7 @@ dependencies = [
  "ggcat_kmers_transform",
  "ggcat_structs",
  "ggcat_utils",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.2",
  "itertools 0.10.5",
  "matchtigs",
  "nightly-quirks",
@@ -1515,6 +1513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,17 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
-dependencies = [
- "hermit-abi 0.3.2",
- "rustix 0.38.2",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,12 +1748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
-
-[[package]]
 name = "lock_api"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lz4"
@@ -1800,18 +1791,18 @@ checksum = "a8ca8afbe8af1785e09636acb5a41e08a765f5f0340568716c18a8700ba3c0d3"
 
 [[package]]
 name = "matchtigs"
-version = "1.7.0"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af20d64559b10390740f1a1f69a3c58b6694a78f52c4b2ced782d96f4f875b2"
+checksum = "e76a8f7456dc5d53bddf3678a31de2d3594653ecb1df243bb8212ac9dcca3961"
 dependencies = [
  "atomic-counter",
- "clap 4.3.10",
+ "clap 4.4.7",
  "crossbeam",
  "disjoint-sets",
  "flate2",
  "genome-graph",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
+ "hashbrown 0.14.2",
+ "itertools 0.11.0",
  "log",
  "memory-stats",
  "permutation",
@@ -2223,7 +2214,7 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2284,13 +2275,13 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "chrono",
  "flate2",
  "hex",
  "lazy_static",
- "rustix 0.36.14",
+ "rustix",
 ]
 
 [[package]]
@@ -2391,7 +2382,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -2400,7 +2391,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -2510,25 +2501,12 @@ version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.4",
+ "linux-raw-sys",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
-dependencies = [
- "bitflags 2.3.3",
- "errno",
- "libc",
- "linux-raw-sys 0.4.3",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2835,18 +2813,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.41"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.41"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -2992,11 +2970,11 @@ dependencies = [
 
 [[package]]
 name = "traitgraph"
-version = "2.2.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c040e85b07a988cc5e2ec76ff2629abd4dc298f345ed605130ab48a5c898a1"
+checksum = "a66933f4a960dc78d44acff16f192c2483de79da8af184c51e5ee128205a78f4"
 dependencies = [
- "bitvector",
+ "bitvec",
  "num-traits",
  "petgraph",
  "traitsequence",
@@ -3004,20 +2982,20 @@ dependencies = [
 
 [[package]]
 name = "traitgraph-algo"
-version = "5.4.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081be3155124961aa6d839591352018f127ed623e17bc236ed194283a2bad918"
+checksum = "7b20270073caa8de64c3f37449b256ab8ada29787f73882f4d44f3fd4d7037d3"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.2",
  "rand",
  "traitgraph",
 ]
 
 [[package]]
 name = "traitsequence"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43e9c5a3771f5149c0290c829e87524803a89e466c5d170d0b14face79b299d"
+checksum = "c4cd2caadbd36e66fb9aea075afd8c4e693773b276e9842928fb2c8a8d29d889"
 
 [[package]]
 name = "triple_accel"

--- a/crates/assembler/Cargo.toml
+++ b/crates/assembler/Cargo.toml
@@ -33,9 +33,9 @@ structs = { package = "ggcat_structs", path = "../structs" }
 
 
 # Matchtigs support
-matchtigs = "1.5.5"
-genome-graph = { version = "5.1.1", features = ["traitgraph-algo"] }
-traitgraph-algo = { version = "5.3.0", features = ["hashbrown_dijkstra_node_weight_array"] }
+matchtigs = "2.1.6"
+genome-graph = { version = "8.0.0", features = ["traitgraph-algo"] }
+traitgraph-algo = { version = "8.1.0", features = ["hashbrown_dijkstra_node_weight_array"] }
 
 
 # Other libraries
@@ -43,7 +43,7 @@ typenum = "1.16.0"
 parking_lot = "0.12.1"
 fs_extra = "1.3.0"
 rayon = "1.7.0"
-hashbrown = "0.13.2"
+hashbrown = "0.14.2"
 itertools = "0.10.5"
 byteorder = "1.4.3"
 serde = "1.0.160"

--- a/crates/assembler/src/pipeline/compute_matchtigs.rs
+++ b/crates/assembler/src/pipeline/compute_matchtigs.rs
@@ -7,6 +7,7 @@ use genome_graph::bigraph::implementation::node_bigraph_wrapper::NodeBigraphWrap
 use genome_graph::bigraph::interface::BidirectedData;
 use genome_graph::bigraph::traitgraph::implementation::petgraph_impl::PetGraph;
 use genome_graph::bigraph::traitgraph::interface::ImmutableGraphContainer;
+use genome_graph::bigraph::traitgraph::interface::MutableGraphContainer;
 use genome_graph::generic::{GenericEdge, GenericNode};
 use hashes::{HashFunctionFactory, MinimizerHashFunctionFactory};
 use io::compressed_read::CompressedReadIndipendent;
@@ -95,6 +96,14 @@ impl<ColorInfo: IdentSequenceWriter> BidirectedData for UnitigEdgeData<ColorInfo
         }
     }
 }
+
+/*impl<ColorInfo: IdentSequenceWriter> BidirectedData for UnitigEdgeData<ColorInfo> {
+
+}
+
+impl<ColorInfo: IdentSequenceWriter> DijkstraWeightedEdgeData<usize> for UnitigEdgeData<ColorInfo> {
+
+}*/
 
 // SequenceHandle is the type that points to a sequence, e.g. just an integer.
 impl<ColorInfo: IdentSequenceWriter> MatchtigEdgeData<SequenceHandle<ColorInfo>>
@@ -340,7 +349,7 @@ pub fn compute_matchtigs_thread<
         .start_phase(format!("phase: {} building [step1]", phase_name));
 
     /* assign weight to each edge */
-    for edge_index in graph.edge_indices() {
+    for edge_index in graph.edge_indices_copied() {
         let edge_data: &mut UnitigEdgeData<_> = graph.edge_data_mut(edge_index);
 
         // length (in characters) of the sequence associated with edge_data

--- a/crates/capi/ggcat-cpp-api/src/ggcat-cpp-bindings.hh
+++ b/crates/capi/ggcat-cpp-api/src/ggcat-cpp-bindings.hh
@@ -337,7 +337,7 @@ typename Slice<T>::iterator::difference_type
 Slice<T>::iterator::operator-(const iterator &other) const noexcept {
   auto diff = std::distance(static_cast<char *>(other.pos),
                             static_cast<char *>(this->pos));
-  return diff / this->stride;
+  return diff / static_cast<typename Slice<T>::iterator::difference_type>(this->stride);
 }
 
 template <typename T>


### PR DESCRIPTION
I also updated hashbrown for good measure, since it is also used by matchtigs.