### PR TITLE
 Fix header dependency issues when building with GCC 13

### DIFF
--- a/crates/capi/ggcat-cpp-api/include/ggcat.hh
+++ b/crates/capi/ggcat-cpp-api/include/ggcat.hh
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 
 namespace ggcat
 {


### PR DESCRIPTION
Fixes building the ggcat C++ API with GCC 13 which currently fails because of a missing `#include <cstdint>` in `ggcat.hh` (see "Header dependency" in https://gcc.gnu.org/gcc-13/porting_to.html for the why).