### PR TITLE
Change number of dedicated threads

### DIFF
--- a/crates/kmers_transform/src/lib.rs
+++ b/crates/kmers_transform/src/lib.rs
@@ -238,7 +238,7 @@ impl<F: KmersTransformExecutorFactory> KmersTransform<F> {
             buckets_list
         };
 
-        let compute_threads_count = max(1, threads_count);
+        let compute_threads_count = max(1, threads_count / 4);
         let read_threads_count = max(1, threads_count / 4 * 3);
 
         let max_buckets = max(MAXIMUM_SECOND_BUCKETS_COUNT, compute_threads_count);


### PR DESCRIPTION
Hi @Guilucand — When processing some data with GGCAT, @jamshed and I noticed that sometimes the number of threads in use can _substantially_ exceed the thread count requested by the user.  This increased CPU usage typically does not last the entire duration of the run, but it does happen for an extended duration of time during the initial phases of the algorithm.  Specifically, we noticed that when requesting 16 threads, we were seeing peak CPU usage ~2800% or about (7/4) * the user requested thread count.

There are several places in the code where the thread count is passes around between components, but this was the first one that stood out.  Here, the number of compute and read threads is set based on dividing up the total number of threads, and later those threads are spawned.  However, the current allocation allots a sum equal to substantially more threads than the initial `threads_count`. This addresses that discrepancy by ensuring that `compute_threads_count` + `read_threads_count` doesn't exceed `threads_count`.

Of course, I'm not sure if this is the partition of the work you want, or if you want to use a fixed partition to begin with, but hopefully this will be useful in figuring out how to address the discrepancy between the requested thread count and the actual peak usage.